### PR TITLE
Add virtual environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Path to your movies directory
+MOVIES_DIR=/path/to/Movies
+
+# Secret key for Flask sessions
+SECRET_KEY=change_this_secret

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Local Media Stream
+
+This project provides a simple way to stream local video files with optional subtitle support. A Flask web interface allows browsing a movies folder, selecting a video and subtitle file, and starting the streaming process.
+
+## Requirements
+
+- Python 3.8+
+- FFmpeg installed and available in your `PATH`
+
+Use a virtual environment and install dependencies from `requirements.txt`.
+
+## Environment Variables
+
+- `MOVIES_DIR` (optional): Base directory containing your video files. Defaults to `~/Movies` if not set.
+- `SECRET_KEY` (optional): Flask session secret. Defaults to `change_this_secret`.
+
+## Running the Application
+
+1. Create and activate a virtual environment:
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Copy `.env.example` to `.env` and adjust the values if needed.
+
+4. Ensure FFmpeg is installed on your system and accessible from the command line.
+
+5. Run the Flask app:
+
+   ```bash
+   python app.py
+   ```
+
+   The interface will be available at `http://localhost:5000`.
+
+6. Use the web interface to browse your `MOVIES_DIR`, select a video and optionally a subtitle file, set a subtitle delay (default is 1.5 seconds), and start streaming. The streaming output will be available at the displayed URL (`http://localhost:8000/output.m3u8`).
+
+## Notes
+
+If your movies folder is synchronized with a cloud storage provider such as OneDrive, the application will attempt to access the selected files so that they are downloaded locally before streaming.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,104 @@
+import os
+import threading
+from flask import Flask, request, redirect, url_for, render_template_string, session
+from dotenv import load_dotenv
+
+from stream import run_ffmpeg, validate_paths
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+# Base directory with video files
+MOVIES_DIR = os.getenv("MOVIES_DIR", os.path.expanduser("~/Movies"))
+
+app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "change_this_secret")
+
+def secure_path(rel_path: str) -> str:
+    """Return an absolute path inside MOVIES_DIR."""
+    abs_path = os.path.abspath(os.path.join(MOVIES_DIR, rel_path))
+    if not abs_path.startswith(os.path.abspath(MOVIES_DIR)):
+        raise ValueError("Invalid path")
+    return abs_path
+
+def ensure_local(path: str) -> None:
+    """Attempt to access the file so that OneDrive downloads it if needed."""
+    try:
+        with open(path, 'rb') as f:
+            f.read(1)
+    except Exception as exc:
+        print(f"Warning: could not access {path}: {exc}")
+
+@app.route('/')
+def browse():
+    rel_path = request.args.get('path', '')
+    abs_path = secure_path(rel_path)
+
+    entries = []
+    for name in sorted(os.listdir(abs_path)):
+        full = os.path.join(abs_path, name)
+        entries.append({'name': name, 'is_dir': os.path.isdir(full)})
+
+    template = '''
+    <h1>Browse {{ rel_path or '/' }}</h1>
+    {% if session.get('video') %}<p>Video: {{ session['video'] }}</p>{% endif %}
+    {% if session.get('subtitle') %}<p>Subtitle: {{ session['subtitle'] }}</p>{% endif %}
+    <form action="{{ url_for('start_stream') }}" method="post">
+        Delay (s): <input name="delay" value="{{ session.get('delay', 1.5) }}">
+        <input type="submit" value="Start Streaming">
+    </form>
+    <ul>
+        {% if rel_path %}<li><a href="{{ url_for('browse', path=parent) }}">..</a></li>{% endif %}
+        {% for e in entries %}
+            {% if e.is_dir %}
+                <li>[DIR] <a href="{{ url_for('browse', path=join(rel_path, e.name)) }}">{{ e.name }}</a></li>
+            {% else %}
+                <li>{{ e.name }} - <a href="{{ url_for('select_file', type='video', path=join(rel_path, e.name)) }}">video</a>
+                <a href="{{ url_for('select_file', type='subtitle', path=join(rel_path, e.name)) }}">subtitle</a></li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+    '''
+    return render_template_string(template, entries=entries, rel_path=rel_path,
+                                  parent=os.path.dirname(rel_path), join=os.path.join)
+
+@app.route('/select')
+def select_file():
+    ftype = request.args.get('type')
+    rel_path = request.args.get('path')
+    if ftype not in {'video', 'subtitle'} or rel_path is None:
+        return 'Invalid selection', 400
+    abs_path = secure_path(rel_path)
+    if not os.path.isfile(abs_path):
+        return 'Not a file', 400
+    session[ftype] = rel_path
+    return redirect(url_for('browse', path=os.path.dirname(rel_path)))
+
+@app.route('/start', methods=['POST'])
+def start_stream():
+    delay = float(request.form.get('delay', 1.5))
+    session['delay'] = delay
+    video_rel = session.get('video')
+    if not video_rel:
+        return 'No video selected', 400
+    subtitle_rel = session.get('subtitle')
+
+    movie_path = secure_path(video_rel)
+    subtitle_path = secure_path(subtitle_rel) if subtitle_rel else None
+
+    validate_paths(movie_path, subtitle_path)
+    ensure_local(movie_path)
+    if subtitle_path:
+        ensure_local(subtitle_path)
+
+    movie_folder = os.path.dirname(movie_path)
+    stream_folder = os.path.join(movie_folder, 'stream')
+
+    def worker():
+        run_ffmpeg(movie_path, subtitle_path, stream_folder, 8000, delay)
+
+    threading.Thread(target=worker, daemon=True).start()
+    return 'Streaming started on http://localhost:8000/output.m3u8'
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+python-dotenv

--- a/stream.py
+++ b/stream.py
@@ -18,7 +18,11 @@ import shutil
 import socketserver
 import subprocess
 import sys
+from dotenv import load_dotenv
 from typing import NoReturn
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 # Global variable to store the stream folder path for cleanup
 STREAM_FOLDER_PATH = None
@@ -223,8 +227,9 @@ def main() -> None:
     """
     args = parse_arguments()
 
-    # Adjust this to your actual Movies directory path
-    movies_dir = "/Users/a57321/Movies"
+    # Directory containing your movies. Can be overridden with the MOVIES_DIR
+    # environment variable. Defaults to ~/Movies if not specified.
+    movies_dir = os.getenv("MOVIES_DIR", os.path.expanduser("~/Movies"))
 
     # Build absolute paths
     movie_path = os.path.join(movies_dir, args.movie_rel_path)


### PR DESCRIPTION
## Summary
- load environment variables from a .env file using `python-dotenv`
- configure Flask `SECRET_KEY` from environment
- add requirements.txt and .env.example
- update README with virtualenv instructions

## Testing
- `python -m py_compile stream.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846ebe308e4832cafef473dde0e583a